### PR TITLE
Fix EOF error 

### DIFF
--- a/sitemap.go
+++ b/sitemap.go
@@ -44,6 +44,10 @@ var fetch = func(URL string, options interface{}) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
+	if res.ContentLength == 0 {
+		return body, errors.New("content length is 0")
+	}
+
 	return ioutil.ReadAll(res.Body)
 }
 
@@ -86,7 +90,8 @@ func (s *Index) get(data []byte, options interface{}) (Sitemap, error) {
 		time.Sleep(interval)
 		data, err := fetch(s.Loc, options)
 		if err != nil {
-			return smap, err
+			// continue with next sitemap on error
+			continue
 		}
 
 		err = xml.Unmarshal(data, &smap)

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -18,6 +18,7 @@ var getTests = []getTest{
 	{"sitemap.xml", true, 13, "normal test"},
 	{"empty.xml", false, 0, "This sitemap.xml is not exist."},
 	{"sitemapindex.xml", true, 39, "sitemap index test"},
+	{"sitemap-5.xml", false, 0, "Sitemap is empty"},
 }
 
 func TestGet(t *testing.T) {
@@ -54,7 +55,7 @@ func TestParseIndex(t *testing.T) {
 	data, _ := ioutil.ReadFile("./testdata/sitemapindex.xml")
 	idx, _ := ParseIndex(data)
 
-	if len(idx.Sitemap) != 3 {
+	if len(idx.Sitemap) != 4 {
 		t.Error("ParseIndex() should return Index.Sitemap(3 length)")
 	}
 }

--- a/testdata/sitemapindex.xml
+++ b/testdata/sitemapindex.xml
@@ -13,4 +13,8 @@
 		<loc>http://HOST/sitemap-3.xml</loc>
 		<lastmod>2015-05-10T15:42:38+00:00</lastmod>
 	</sitemap>
+	<sitemap>
+		<loc>http://HOST/sitemap-5.xml</loc>
+		<lastmod>2015-05-10T15:42:38+00:00</lastmod>
+	</sitemap>
 </sitemapindex>


### PR DESCRIPTION
When I read a sitemapindex.xml file and in the sitemapindex.xml is a URL to an empty sitemap.xml (Content-Length = 0), I got an EOF error. I fixed this by return an error in `fetch` and continue the for loop in `get()`. I have updated the tests. 